### PR TITLE
Capture ScriptBlock source code from the topmost frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - StackTrace parsing on Windows Powershell 5.1 ([#50](https://github.com/getsentry/sentry-powershell/pull/50))
+- Context lines captured for PowerShell executed directly as a ScriptBlock  ([#60](https://github.com/getsentry/sentry-powershell/pull/60))
 
 ### Dependencies
 

--- a/modules/Sentry/public/Out-Sentry.ps1
+++ b/modules/Sentry/public/Out-Sentry.ps1
@@ -64,7 +64,7 @@ function Out-Sentry
             {
                 # Note: we use ScriptStackTrace even though we need to parse it, becaause it contains actual stack trace
                 # to the throw, not just the trace to the call to this function.
-                $processor.StackTraceString = @($ErrorRecord.ScriptStackTrace -split "[`r`n]+")
+                $processor.StackTraceString = $ErrorRecord.ScriptStackTrace -split "[`r`n]+"
                 $processor.InvocationInfo = $ErrorRecord.InvocationInfo
             }
 
@@ -92,6 +92,15 @@ function Out-Sentry
         {
             Write-Debug 'Out-Sentry: Nothing to capture'
             return
+        }
+
+        # Use the PSCallStack to capture the source code of the main script that is being executed.
+        # This is used as a fallback in case the code is executed directly as a ScriptBlock from a hosted .NET environment with no .ps1 file.
+        # If the top frame is Script (i.e. the code is executed as a script file), we don't need to capture the source code.
+        $TopFrame = Get-PSCallStack | Select-Object -Last 1
+        if ("Script" -ne $TopFrame.InvocationInfo.MyCommand.CommandType)
+        {
+            $processor.ScriptBlockSource = $TopFrame.InvocationInfo.MyCommand.ScriptBlock.ToString() -split "`r`n"
         }
 
         if ($options.AttachStackTrace -and $null -eq $processor.StackTraceFrames -and $null -eq $processor.StackTraceString)


### PR DESCRIPTION
As a fallback for environments where PowerShell is executed directly from .NET as a ScriptBlock

Ensure StackTraceString matches InvocationInfo when ScriptName is blank